### PR TITLE
Require Filament ^5.0 and Livewire ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,10 @@
         "illuminate/contracts": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0",
         "laravel/prompts": "^0.1.0|^0.3.0",
-        "livewire/livewire": "^3.0",
+        "livewire/livewire": "^4.0",
         "phpseclib/phpseclib": "^3.0",
-        "symfony/process": "^7.0"
+        "symfony/process": "^7.0",
+        "filament/filament": "^5.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
@@ -34,9 +35,6 @@
         "orchestra/testbench": "^9.0|^10.0",
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0"
-    },
-    "suggest": {
-        "filament/filament": "Required for Filament admin panel integration (^3.0)"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hello,

Currently the web-terminal only works with Filament ^4.0.

My only change is to require filament/filament ^5.0 and this needs livewire/livewire to be ^4.0

Filament 5 doesn't include any changes really, so this is a safe upgrade.
Livewire does have 2 low impact changes, the first one is about CDN's, so this isn't a concern, and the second one about `$wire.$js` isn't being used in the web-terminal. So I'm sure this is also a safe upgrade.

The only catch is that when running `composer test` I do have some failures, many about SSH, this is to be expected on my machine since I don't have a SSH server running. But also a handful of others, this is pretty much the same before and after the upgrade:

Before the upgrade:
```
  Tests:    14 failed, 708 passed (1515 assertions)
  Duration: 9.54s
```

After the upgrade:
```
  Tests:    13 failed, 709 passed (1516 assertions)
  Duration: 9.66s
```

I'm just going to assume that this is to be expected, if this is not the case, I can look into it.

At last, I've seen it possible to support both Filament 4.0 and 5.0, but I when only for the 5.0, because anyone on 4.0 can just install the older version (if this is released as v1.0.1)

Thanks in advance

-Wouter